### PR TITLE
Fix permissions in plugin.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -10,7 +10,10 @@ commands:
     usage: "/combiner"
     aliases: [comb, combin]
     permission: combiner.command
-  permissions:
-    combiner.command:
-    description: "Allows players to use the CombinerGUI"
-    default: true
+
+permissions:
+  combiner:
+    children:
+      combiner.command:
+        description: "Allows players to use the CombinerGUI"
+        default: true


### PR DESCRIPTION
This PR fixes the permission "combiner.command" that was not being registered due to the wrong indentation. This PR also add a root permission "combiner" for the sake of completeness.